### PR TITLE
Add show data toggle and table links for profile stats

### DIFF
--- a/censusreporter/apps/census/templates/profile/_blocks/_stat_list.html
+++ b/censusreporter/apps/census/templates/profile/_blocks/_stat_list.html
@@ -1,4 +1,4 @@
-{% load humanize comparatives %}
+{% load humanize comparatives cr_json_script %}
 {% if not stat_wrapper == 'false' %}<a class="stat {{ stat_type }}{% if wrapper_class %} {{ wrapper_class }}{% endif %}">{% endif %}
     <span class="{% if stat_class %}{{ stat_class }}{% else %}primary{% endif %}">
         <span class="value">
@@ -45,3 +45,11 @@
     </ul>
     {% endif %}
 {% if not stat_wrapper == 'false' %}</a>{% endif %}
+{% if stat.metadata %}
+    {% with stat_id=stat.metadata.table_id|slugify|add:'-'|add:stat.name|slugify %}
+        {{ stat|cr_json_script:stat_id }}
+        <div class="action-links">
+            <a class="stat-get-data" data-stat-id="{{ stat_id }}" data-stat-type="{{ stat_type }}">Show data</a>
+        </div>
+    {% endwith %}
+{% endif %}


### PR DESCRIPTION
## Summary
- include metadata-driven "Show data" links for big number stats on profiles
- reveal inline table with "View table" link for source ACS tables

## Testing
- `node --check censusreporter/apps/census/static/js/app.js`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'corsheaders')*

------
https://chatgpt.com/codex/tasks/task_e_68bc3d1fda9c83289460ebd2b6b2af72